### PR TITLE
testng-eclipse #225: update docs about dropping support for Eclipse 3.x

### DIFF
--- a/doc/download.html
+++ b/doc/download.html
@@ -88,15 +88,7 @@ repositories {
   <li><i>Search for new features to install.</i></li>
   <li><i>New remote site.</i></li>
   <li>Eclipse 4.2 and above - Enter <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>.</li>
-  <li>Eclipse 3.x - Not supported any more, please update your Eclipse to 4.2 or above.
-    <ul>
-      if you unfortunately have to stick with Eclipse 3.x, you may try below, but with no support:
-      <li>Eclipse 3.6, 3.7 - you still can try to install the latest version of plug-ins from update site <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>; if it does not work, you can install older versions of the plug-ins from update site <a href="http://beust.com/eclipse-old">http://beust.com/eclipse-old</a>, at the time writing this guide, TestNG for Eclipse 6.9.10 still works.</li>
-      <li>Eclipse 3.4, 3.5 - unfortunately, no working plugin for them, please update to higer version of Eclipse and follow the corresponding guide.</li>
-      <li>Eclipse 3.3 and below - it's recommanded to update to higer version of Eclipse and follow the corresponding guide. <br/>
-      However, if it's not an option, you may try to install from <a href="http://beust.com/eclipse1">http://beust.com/eclipse1</a>.</li>
-    </ul>
-  </li>
+  <li>Eclipse 3.x - Not supported any more, please update your Eclipse to 4.2 or above.</li>
   <li>Make sure the check box next to URL is checked and click <i>Next</i>.</li>
   <li>Eclipse will then guide you through the process. </li>
 </ul>

--- a/doc/download.html
+++ b/doc/download.html
@@ -82,25 +82,32 @@ repositories {
 </pre>
 
 <h3>Eclipse plug-in</h3>
-<p>You can use either the Eclipse Market Place or the update site:</p>
+<p>You can use either the <a href="http://marketplace.eclipse.org/content/testng-eclipse">Eclipse Marketplace</a> or the update site:</p>
+
+<h4>Install via Eclipse Marketplace</h4>
+<a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1549" class="drag" title="Drag to your running Eclipse workspace to install TestNG for Eclipse"><img class="img-responsive" src="http://marketplace.eclipse.org/sites/all/themes/solstice/_themes/solstice_marketplace/public/images/btn-install.png" alt="Drag to your running Eclipse workspace to install TestNG for Eclipse" /></a>
+
+<h4>Install from update site</h4>
 <ul>
-  <li>Select<i> Help / Install new software.</i></li>
-  <li><i>Search for new features to install.</i></li>
-  <li><i>New remote site.</i></li>
-  <li>Eclipse 4.2 and above - Enter <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>.</li>
-  <li>Eclipse 3.x - Not supported any more, please update your Eclipse to 4.2 or above.</li>
+  <li>Select<i> Help / Install New Software...</i></li>
+  <li>Enter the update site URL in "Work with:" field:</li>
+  <ul>
+    <li>Eclipse 4.2 and above - Enter <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>.</li>
+    <li>Eclipse 3.x - Not supported any more, please update your Eclipse to 4.2 or above.</li>
+  </ul>
   <li>Make sure the check box next to URL is checked and click <i>Next</i>.</li>
   <li>Eclipse will then guide you through the process. </li>
 </ul>
 
-<p>Note that the URLs on this page are update sites, not direct download links.
+<p>You can also install older versions of the plug-ins <a href="http://beust.com/eclipse-old">here</a>. Note that the URL's on this page are update sites as well, not direct download links.</p>
 
+<h3>Build TestNG from source code</h3>
 <p>TestNG is also <a href="http://github.com/cbeust/testng">hosted on GitHub</a>, where you can download the source and build the distribution yourself:
 
 <pre class="brush: plain">
 $ git clone git://github.com/cbeust/testng.git
 $ cd testng
-$ mvn package
+$ ./build-with-gradle
 </pre>
 
 <p>You will then find the jar file in the <tt>target</tt> directory</p>

--- a/doc/download.html
+++ b/doc/download.html
@@ -84,21 +84,24 @@ repositories {
 <h3>Eclipse plug-in</h3>
 <p>You can use either the Eclipse Market Place or the update site:</p>
 <ul>
-	<li>Select<i> Help / Install new software.</i> 
-	</li>
-	<li><i>Search for new features to install.</i> 
-	</li>
-	<li><i>New remote site.</i> 
-	</li>
-	<li>For Eclipse 3.4 and above, enter <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>.
-	<li>For Eclipse 3.3 and below, enter <a href="http://beust.com/eclipse1">http://beust.com/eclipse1</a>.
-	</li>
-	<li>Make sure the check box next to URL is checked and click <i>Next</i>. 
-	</li>
-	<li>Eclipse will then guide you through the process. </li>
+  <li>Select<i> Help / Install new software.</i></li>
+  <li><i>Search for new features to install.</i></li>
+  <li><i>New remote site.</i></li>
+  <li>Eclipse 4.2 and above - Enter <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>.</li>
+  <li>Eclipse 3.x - Not supported any more, please update your Eclipse to 4.2 or above.
+    <ul>
+      if you unfortunately have to stick with Eclipse 3.x, you may try below, but with no support:
+      <li>Eclipse 3.6, 3.7 - you still can try to install the latest version of plug-ins from update site <a href="http://beust.com/eclipse">http://beust.com/eclipse</a>; if it does not work, you can install older versions of the plug-ins from update site <a href="http://beust.com/eclipse-old">http://beust.com/eclipse-old</a>, at the time writing this guide, TestNG for Eclipse 6.9.10 still works.</li>
+      <li>Eclipse 3.4, 3.5 - unfortunately, no working plugin for them, please update to higer version of Eclipse and follow the corresponding guide.</li>
+      <li>Eclipse 3.3 and below - it's recommanded to update to higer version of Eclipse and follow the corresponding guide. <br/>
+      However, if it's not an option, you may try to install from <a href="http://beust.com/eclipse1">http://beust.com/eclipse1</a>.</li>
+    </ul>
+  </li>
+  <li>Make sure the check box next to URL is checked and click <i>Next</i>.</li>
+  <li>Eclipse will then guide you through the process. </li>
 </ul>
 
-<p>You can also install older versions of the plug-ins <a href="http://beust.com/eclipse-old">here</a>. Note that the URL's on this page are update sites as well, not direct download links.
+<p>Note that the URLs on this page are update sites, not direct download links.
 
 <p>TestNG is also <a href="http://github.com/cbeust/testng">hosted on GitHub</a>, where you can download the source and build the distribution yourself:
 


### PR DESCRIPTION
update docs for https://github.com/cbeust/testng-eclipse/issues/225