### PR TITLE
testng #995: jre version required for running plugin

### DIFF
--- a/doc/download.html
+++ b/doc/download.html
@@ -82,6 +82,9 @@ repositories {
 </pre>
 
 <h3>Eclipse plug-in</h3>
+
+<p><b>Java 1.7+ is required</b> for running the TestNG for Eclipse plugin.</p>
+
 <p>You can use either the <a href="http://marketplace.eclipse.org/content/testng-eclipse">Eclipse Marketplace</a> or the update site:</p>
 
 <h4>Install via Eclipse Marketplace</h4>


### PR DESCRIPTION
update doc for https://github.com/cbeust/testng/issues/995