### PR TITLE
Move to javadoc.io to fix javadoc rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 old-doc
+**/.DS_Store
 

--- a/doc/ant.html
+++ b/doc/ant.html
@@ -124,9 +124,9 @@ accepts the following attributes: <br>
 	<tr>
 		<td><tt>listeners</tt></td>
 		<td>A comma or space-separated list of fully qualified classes that are TestNG listeners (for example<tt>
-		<a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html">
+		<a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html">
 		org.testng.ITestListener</a></tt> or <tt>
-		<a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IReporter.html">
+		<a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IReporter.html">
 		org.testng.IReporter</a>)</tt></td>
 		<td>No.</td>
 	</tr>
@@ -160,7 +160,7 @@ accepts the following attributes: <br>
 		<td>A fully qualified name of a TestNG starter. </td>
 		<td>
 		<p align="left">No.&nbsp; Defaults to <tt>
-		<a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/TestNG.html">org.testng.TestNG</a> </tt></td>
+		<a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/TestNG.html">org.testng.TestNG</a> </tt></td>
 	</tr>
 	
 	<tr>

--- a/doc/banner.js
+++ b/doc/banner.js
@@ -33,7 +33,7 @@ function displayMenu(pCurrentPage) {
        writeTD(pCurrentPage,          "download.html", "Download")
        writeTD(pCurrentPage,"documentation-main.html", "Documentation")
        writeTD(pCurrentPage,         "migrating.html", "Migrating from JUnit")
-       writeTD(pCurrentPage, "https://jitpack.io/com/github/cbeust/testng/master/javadoc/", "JavaDoc")
+       writeTD(pCurrentPage, "https://javadoc.io/doc/org.testng/testng/latest/index.html", "JavaDoc")
        writeTD(pCurrentPage, "selenium.html", "Selenium")
    document.writeln('            </tr>')
    document.writeln('            <tr>')

--- a/doc/documentation-main.html
+++ b/doc/documentation-main.html
@@ -700,7 +700,7 @@ You need to specify at least one XML file describing the TestNG suite you are tr
   <tr>
             <td>-listener</td>
 	    <td>A comma-separated list of Java classes that can be found on your classpath.</td>
-	    <td>Lets you specify your own test listeners.  The classes need to implement <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html"> <tt>org.testng.ITestListener</tt></a></td>
+	    <td>Lets you specify your own test listeners.  The classes need to implement <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html"> <tt>org.testng.ITestListener</tt></a></td>
         </tr>
   <tr>
     <td>-usedefaultlisteners</td>
@@ -775,7 +775,7 @@ You need to specify at least one XML file describing the TestNG suite you are tr
         <tr>
             <td>-testrunfactory</td>
 	    <td>A Java classes that can be found on your classpath.</td>
-	    <td>Lets you specify your own test runners.  The class needs to implement <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestRunnerFactory.html"> <tt>org.testng.ITestRunnerFactory</tt></a>.</td>
+	    <td>Lets you specify your own test runners.  The class needs to implement <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestRunnerFactory.html"> <tt>org.testng.ITestRunnerFactory</tt></a>.</td>
         </tr>
 
         <tr>
@@ -1182,7 +1182,7 @@ and <tt>jdbc-driver </tt>respectively.&nbsp;
 
 <p>
 
-Parameters can be declared optional with the <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/annotations/Optional.html"><tt>Optional</tt></a> annotation:
+Parameters can be declared optional with the <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/annotations/Optional.html"><tt>Optional</tt></a> annotation:
 
 <pre class="brush: java">
 @Parameters("db")
@@ -1926,9 +1926,9 @@ testng.addListener(tla);
 testng.run(); 
 </pre>
 
-This example creates a <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/TestNG.html">TestNG</a></tt> object and runs the test class <tt>Run2</tt>.  It also adds a <tt>TestListener</tt>.  You can either use the adapter class <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/TestListenerAdapter.html">org.testng.TestListenerAdapter</a></tt> or implement <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html">org.testng.ITestListener</a></tt> yourself.  This interface contains various callback methods that let you keep track of when a test starts, succeeds, fails, etc...
+This example creates a <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/TestNG.html">TestNG</a></tt> object and runs the test class <tt>Run2</tt>.  It also adds a <tt>TestListener</tt>.  You can either use the adapter class <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/TestListenerAdapter.html">org.testng.TestListenerAdapter</a></tt> or implement <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html">org.testng.ITestListener</a></tt> yourself.  This interface contains various callback methods that let you keep track of when a test starts, succeeds, fails, etc...
 <p>
-Similarly, you can invoke TestNG on a <tt>testng.xml</tt> file or you can create a virtual <tt>testng.xml</tt> file yourself.  In order to do this, you can use the classes found the package <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/xml/package-frame.html">org.testng.xml</a></tt>:  <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/xml/XmlClass.html">XmlClass</a></tt>, <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/xml/XmlTest.html">XmlTest</a></tt>, etc...  Each of these classes correspond to their XML tag counterpart.
+Similarly, you can invoke TestNG on a <tt>testng.xml</tt> file or you can create a virtual <tt>testng.xml</tt> file yourself.  In order to do this, you can use the classes found the package <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/xml/package-frame.html">org.testng.xml</a></tt>:  <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/xml/XmlClass.html">XmlClass</a></tt>, <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/xml/XmlTest.html">XmlTest</a></tt>, etc...  Each of these classes correspond to their XML tag counterpart.
 <p>
 For example, suppose you want to create the following virtual file:
 
@@ -1964,7 +1964,7 @@ tng.setXmlSuites(suites);
 tng.run(); 
 </pre>
 
-<p>Please see the <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/package-summary.html" target="mainFrame">JavaDocs</a> for the entire API.</p><p>
+<p>Please see the <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/package-summary.html" target="mainFrame">JavaDocs</a> for the entire API.</p><p>
 
 
 <!-------------------------------------
@@ -2161,14 +2161,14 @@ public List&lt;IMethodInstance&gt; intercept(List&lt;IMethodInstance&gt; methods
 There are several interfaces that allow you to modify TestNG's behavior.  These interfaces are broadly called "TestNG Listeners".  Here are a few listeners:
 
 <ul>
-  <li><tt>IAnnotationTransformer</tt> (<a href="#annotationtransformers">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IAnnotationTransformer.html">javadoc</a>)
-  <li><tt>IAnnotationTransformer2</tt> (<a href="#annotationtransformers">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IAnnotationTransformer2.html">javadoc</a>)
-  <li><tt>IHookable</tt> (<a href="#ihookable">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IHookable.html">javadoc</a>)
-  <li><tt>IInvokedMethodListener</tt> (doc, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IInvokedMethodListener.html">javadoc</a>)
-  <li><tt>IMethodInterceptor</tt> (<a href="#methodinterceptors">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IMethodInterceptor.html">javadoc</a>)
-  <li><tt>IReporter</tt> (<a href="#logging-reporters">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IReporter.html">javadoc</a>)
-  <li><tt>ISuiteListener</tt> (doc, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ISuiteListener.html">javadoc</a>)
-  <li><tt>ITestListener</tt> (<a href="#logging-listeners">doc</a>, <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html">javadoc</a>)
+  <li><tt>IAnnotationTransformer</tt> (<a href="#annotationtransformers">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IAnnotationTransformer.html">javadoc</a>)
+  <li><tt>IAnnotationTransformer2</tt> (<a href="#annotationtransformers">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IAnnotationTransformer2.html">javadoc</a>)
+  <li><tt>IHookable</tt> (<a href="#ihookable">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IHookable.html">javadoc</a>)
+  <li><tt>IInvokedMethodListener</tt> (doc, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IInvokedMethodListener.html">javadoc</a>)
+  <li><tt>IMethodInterceptor</tt> (<a href="#methodinterceptors">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IMethodInterceptor.html">javadoc</a>)
+  <li><tt>IReporter</tt> (<a href="#logging-reporters">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IReporter.html">javadoc</a>)
+  <li><tt>ISuiteListener</tt> (doc, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ISuiteListener.html">javadoc</a>)
+  <li><tt>ITestListener</tt> (<a href="#logging-listeners">doc</a>, <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html">javadoc</a>)
 </ul>
 
 When you implement one of these interfaces, you can let TestNG know about it with either of the following ways:
@@ -2536,7 +2536,7 @@ public class GuiceModuleFactoryTest {
 }
 </pre>
 
-The module factory needs to implement the interface <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IModuleFactory.html">IModuleFactory</a>:
+The module factory needs to implement the interface <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IModuleFactory.html">IModuleFactory</a>:
 
 <pre class="brush: java">
 public interface IModuleFactory {
@@ -2630,7 +2630,7 @@ This configuration ensures you that all tests in this suite will be run with sam
 	
 <h4><a class="section" indent=".." name="invokedmethodlistener">Listening to method invocations</a></h4>
 
-The listener <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IInvokedMethodListener.html">IInvokedMethodListener</a></tt> allows you to be notified whenever TestNG is about to invoke a test (annotated with <tt>@Test</tt>) or configuration (annotated with any of the <tt>@Before</tt> or <tt>@After</tt> annotation) method.  You need to implement the following interface:
+The listener <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IInvokedMethodListener.html">IInvokedMethodListener</a></tt> allows you to be notified whenever TestNG is about to invoke a test (annotated with <tt>@Test</tt>) or configuration (annotated with any of the <tt>@Before</tt> or <tt>@After</tt> annotation) method.  You need to implement the following interface:
 
 <pre class="brush: java">
 public interface IInvokedMethodListener extends ITestNGListener {
@@ -2650,7 +2650,7 @@ and declare it as a listener, as explained in <a href="#testng-listeners">the se
 
 <h4><a class="section" indent=".." name="ihookable">Overriding test methods</a></h4>
 
-TestNG allows you to override and possibly skip the invocation of test methods. One example of where this is useful is if you need to your test methods with a specific security manager. You achieve this by providing a listener that implements <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IHookable.html"><tt>IHookable</tt></a>.
+TestNG allows you to override and possibly skip the invocation of test methods. One example of where this is useful is if you need to your test methods with a specific security manager. You achieve this by providing a listener that implements <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IHookable.html"><tt>IHookable</tt></a>.
 <p>
 Here is an example with JAAS:
 
@@ -2686,7 +2686,7 @@ times and create a new suite xml file and work with. But this doesn't seem to sc
 
 <p>
 TestNG allows you to alter a suite (or) a test tag in your suite xml file at runtime via listeners.
-You achieve this by providing a listener that implements <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IAlterSuiteListener.html"><tt>IAlterSuiteListener</tt></a>.
+You achieve this by providing a listener that implements <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IAlterSuiteListener.html"><tt>IAlterSuiteListener</tt></a>.
 Please refer to <a href="#testng-listeners">Listeners section</a> to learn about listeners.
 <p>
 Here is an example that shows how the suite name is getting altered in runtime:
@@ -2768,7 +2768,7 @@ run.
 It's very easy to generate your own reports with TestNG with Listeners and Reporters:
 
 <ul>
-<li><b>Listeners</b> implement the interface <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html"><tt>org.testng.ITestListener</tt></a> and are notified in real time of when a test starts, passes, fails, etc...</li><li><b>Reporters</b> implement the interface <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IReporter.html"><tt>org.testng.IReporter</tt></a> and are notified when all the suites have been run by TestNG.  The IReporter instance receives a list of objects that describe the entire test run.</li></ul>For example, if you want to generate a PDF report of your test run, you don't need to be notified in real time of the test run so you should probably use an <tt>IReporter</tt>.  If you'd like to write a real-time reporting of your tests, such as a GUI with a progress bar or a text reporter displaying dots (".") as each test is invoked (as is explained below), <tt>ITestListener</tt> is your best choice.
+<li><b>Listeners</b> implement the interface <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html"><tt>org.testng.ITestListener</tt></a> and are notified in real time of when a test starts, passes, fails, etc...</li><li><b>Reporters</b> implement the interface <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IReporter.html"><tt>org.testng.IReporter</tt></a> and are notified when all the suites have been run by TestNG.  The IReporter instance receives a list of objects that describe the entire test run.</li></ul>For example, if you want to generate a PDF report of your test run, you don't need to be notified in real time of the test run so you should probably use an <tt>IReporter</tt>.  If you'd like to write a real-time reporting of your tests, such as a GUI with a progress bar or a text reporter displaying dots (".") as each test is invoked (as is explained below), <tt>ITestListener</tt> is your best choice.
 
 <h5><a class="section" indent="..." name="logging-listeners">Logging Listeners</a></h5>
 
@@ -2802,7 +2802,7 @@ public class DotTestListener extends TestListenerAdapter {
 } 
 </pre>
 
-In this example, I chose to extend <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/TestListenerAdapter.html"><tt>TestListenerAdapter</tt></a>, which implements <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/ITestListener.html"><tt>ITestListener</tt></a> with empty methods, so I don't have to override other methods from the interface that I have no interest in.  You can implement the interface directly if you prefer.
+In this example, I chose to extend <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/TestListenerAdapter.html"><tt>TestListenerAdapter</tt></a>, which implements <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/ITestListener.html"><tt>ITestListener</tt></a> with empty methods, so I don't have to override other methods from the interface that I have no interest in.  You can implement the interface directly if you prefer.
 
 <p>
 Here is how I invoke TestNG to use this new listener:
@@ -2834,7 +2834,7 @@ Note that when you use <tt>-listener</tt>, TestNG will automatically determine t
 
 <h5><a class="section" indent="..." name="logging-reporters">Logging Reporters</a></h5>
 
-The <a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/IReporter.html"><tt>org.testng.IReporter</tt></a> interface only has one method:
+The <a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/IReporter.html"><tt>org.testng.IReporter</tt></a> interface only has one method:
 
 <pre class="brush: java">
 public void generateReport(List&lt;ISuite</a>&gt; suites, String outputDirectory)
@@ -2874,7 +2874,7 @@ get this to work for now.</em>
 <h5><a class="section" indent="..." name="logging-reporter-api">Reporter API</a></h5>
 
 <p>
-If you need to log messages that should appear in the generated HTML reports, you can use the class <tt><a href="https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/Reporter.html">org.testng.Reporter</a></tt>:
+If you need to log messages that should appear in the generated HTML reports, you can use the class <tt><a href="https://javadoc.io/doc/org.testng/testng/latest/org/testng/Reporter.html">org.testng.Reporter</a></tt>:
 
 <blockquote class="brush: text">
 <font color="#ffffff">&nbsp;&nbsp;&nbsp;&nbsp;</font><font color="#000000">Reporter.log</font><font color="#000000">(</font><font color="#2a00ff">&#34;M3 WAS CALLED&#34;</font><font color="#000000">)</font><font color="#000000">;</font>


### PR DESCRIPTION
This PR fixes the discrepancy in the javadoc rendering as reported in this thread

https://groups.google.com/g/testng-dev/c/L7_c4pTbIFs/m/k4L1zJkpBgAJ