### PR TITLE
Fix typo in overridable configure() method

### DIFF
--- a/src/main/asciidoc/docs/dependency_injection.adoc
+++ b/src/main/asciidoc/docs/dependency_injection.adoc
@@ -226,7 +226,7 @@ package com.example;
 
 public class ParentModule extends AbstractModule {
   @Override
-  protected void conigure() {
+  protected void configure() {
     bind(MyService.class).toProvider(MyServiceProvider.class);
     bind(MyContext.class).to(MyContextImpl.class).in(Singleton.class);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the method name from `conigure` to `configure` in the `ParentModule` class to ensure proper configuration of bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->