### PR TITLE
Replace obsolete git:// protocol with https:// protocol

### DIFF
--- a/archive/doc/download.html
+++ b/archive/doc/download.html
@@ -100,7 +100,7 @@ Go to the <a href="https://marketplace.eclipse.org/content/testng-eclipse">TestN
 <p>TestNG is also <a href="https://github.com/cbeust/testng">hosted on GitHub</a>, where you can download the source and build the distribution yourself:
 
 <pre class="brush: plain">
-$ git clone git://github.com/cbeust/testng.git
+$ git clone https://github.com/cbeust/testng.git
 $ cd testng
 $ ./gradlew build
 </pre>

--- a/src/main/asciidoc/download.adoc
+++ b/src/main/asciidoc/download.adoc
@@ -49,7 +49,7 @@ TestNG is also hosted on GitHub, where you can download the source and build the
 [source,shell]
 
 ----
-$ git clone git://github.com/testng-team/testng.git
+$ git clone https://github.com/testng-team/testng.git
 $ cd testng
 $ ./gradlew build
 ----


### PR DESCRIPTION
## Replace obsolete `git://` protocol with `https://` protocol

GitHub stopped supporting the unauthenticated `git://` protocol in 2022.  Refer to the [announcement blog post](https://github.blog/security/application-security/improving-git-protocol-security-github/) for more details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git repository clone URL to use HTTPS protocol in TestNG source build instructions for improved security and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->