### PR TITLE
feat(schema): publish testng-1.1.xsd, and refresh the DTD it sits next to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
                                     </includes>
                                 </resource>
                                 <resource>
+                                    <directory>src/main/resources/schema</directory>
+                                    <includes>
+                                        <include>**/*.xsd</include>
+                                    </includes>
+                                </resource>
+                                <resource>
                                     <directory>src/main/resources/tocbot-3_0_2</directory>
                                     <includes>
                                         <include>**/*.css</include>

--- a/src/main/resources/dtd/testng-1.1.dtd
+++ b/src/main/resources/dtd/testng-1.1.dtd
@@ -35,7 +35,6 @@ Cedric Beust & Alexandru Popescu
 <!-- Attributes: -->
 <!--
 @attr  name        The name of this suite (as it will appear in the reports)
-@attr  junit       Whether to run in JUnit mode.
 @attr  verbose     How verbose the output on the console will be.  
                 This setting has no impact on the HTML reports.
 @attr  parallel   Whether TestNG should use different threads
@@ -62,11 +61,15 @@ for running both regular and data driven tests in parallel. (Works only with Tes
       for running parallel data providers. (Works only with TestNG versions 7.9.0 or higher)
 @attr  object-factory A class that implements IObjectFactory that will be used to
        instantiate the test objects.
+@attr lazy-factory If true, @Factory produced test class instances are created lazily
+      (just-in-time, right before the first configuration/test method of each instance runs)
+      instead of eagerly up-front. Honored only for constructor based factories. When unset,
+      the TestNG configuration decides (default eager). A @Factory(lazy=...) annotation value
+      overrides this suite level attribute.
 @attr allow-return-values If true, tests that return a value will be run as well
 -->
 <!ATTLIST suite
     name CDATA #REQUIRED
-    junit (true | false) "false"
     verbose CDATA #IMPLIED
     parallel (false | true | none | methods | tests | classes | instances) "none"
     parent-module CDATA #IMPLIED
@@ -81,6 +84,7 @@ for running both regular and data driven tests in parallel. (Works only with Tes
     share-thread-pool-for-data-providers (true | false) "false"
     object-factory CDATA #IMPLIED
     group-by-instances (true | false) "false"
+    lazy-factory (true | false) #IMPLIED
     preserve-order (true | false) "true"
     allow-return-values (true | false) "false"
 >
@@ -127,7 +131,6 @@ A test contains parameters and classes.  Additionally, you can define additional
 
 <!--
 @attr  name         The name of this test (as it will appear in the reports)
-@attr  junit        Whether to run in JUnit mode.
 @attr  verbose      How verbose the output on the console will be.
                 This setting has no impact on the HTML reports.
                 Default value: suite level verbose.
@@ -149,7 +152,6 @@ found in the XML file.
 -->
 <!ATTLIST test
     name CDATA #REQUIRED 
-    junit (true | false) "false"
     verbose  CDATA #IMPLIED
     parallel  (false | true | none | methods | tests | classes | instances) #IMPLIED
     thread-count CDATA #IMPLIED

--- a/src/main/resources/schema/testng-1.1.xsd
+++ b/src/main/resources/schema/testng-1.1.xsd
@@ -1,0 +1,603 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  An XML Schema rendering of testng-1.1.dtd, declaration for declaration.
+
+  It carries no targetNamespace on purpose: suite files have never declared an xmlns, so a
+  namespace would be a breaking change for every existing testng.xml. That is reserved for a
+  future 2.0 of the schema.
+
+  The DTD stays authoritative for files carrying a <!DOCTYPE>. This schema exists so that tools
+  which cannot consume a DTD (IDE completion, XSD-only validators) have the same contract.
+  SchemaConsistencyTest fails the build when the two stop agreeing on the elements, the
+  attributes, their defaults or their enumerations.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:annotation>
+    <xsd:documentation>
+      Here is a quick overview of the main parts of this schema. For more information, refer to
+      the main web site, https://testng.org.
+
+      A suite is made of tests and parameters.
+
+      A test is made of three parts: parameters, which override the suite parameters; groups,
+      made of two parts; and classes, defining which classes are going to be part of this test
+      run.
+
+      In turn, groups are made of two parts: definitions, which allow you to group groups into
+      bigger groups, and runs, which define the groups that the methods must belong to in order
+      to be run during this test.
+
+      Cedric Beust and Alexandru Popescu
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="suite">
+    <xsd:annotation>
+      <xsd:documentation>
+        A suite is the top-level element of a testng.xml file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="groups" minOccurs="0"/>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+          <xsd:element ref="listeners"/>
+          <xsd:element ref="packages"/>
+          <xsd:element ref="test"/>
+          <xsd:element ref="parameter"/>
+          <xsd:element ref="method-selectors"/>
+          <xsd:element ref="suite-files"/>
+        </xsd:choice>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            The name of this suite (as it will appear in the reports).
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="verbose" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            How verbose the output on the console will be. This setting has no impact on the
+            HTML reports.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="parallel" type="parallelMode" default="none">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether TestNG should use different threads to run your tests (might speed up the
+            process). Do not use "true" and "false" values, they are now deprecated.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="parent-module" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A module used to create the parent injector of all guice injectors used in tests of
+            the suite.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="guice-stage" type="guiceStage" default="DEVELOPMENT">
+        <xsd:annotation>
+          <xsd:documentation>
+            The stage with which the parent injector is created.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="configfailurepolicy" type="configFailurePolicy" default="skip">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether to continue attempting Before/After Class/Methods after they have failed
+            once, or just skip the remaining ones.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="thread-count" type="xsd:string" default="5">
+        <xsd:annotation>
+          <xsd:documentation>
+            An integer giving the size of the thread pool to use if you set parallel.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="annotations" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            If "javadoc", TestNG will look for JavaDoc annotations in your sources, otherwise it
+            will use JDK5 annotations.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="time-out" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The time to wait in milliseconds before aborting the method (if parallel="methods")
+            or the test (if parallel="tests").
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="skipfailedinvocationcounts" type="trueOrFalse" default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether to skip failed invocations.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="use-global-thread-pool" type="trueOrFalse" default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether TestNG should use a common thread pool for running both regular and data
+            driven tests in parallel. (Works only with TestNG versions 7.9.0 or higher.)
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="data-provider-thread-count" type="xsd:string" default="10">
+        <xsd:annotation>
+          <xsd:documentation>
+            An integer giving the size of the thread pool to use for parallel data providers.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="share-thread-pool-for-data-providers" type="trueOrFalse"
+                     default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether TestNG should use a common thread pool for running parallel data providers.
+            (Works only with TestNG versions 7.9.0 or higher.)
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="object-factory" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A class that implements IObjectFactory that will be used to instantiate the test
+            objects.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="group-by-instances" type="trueOrFalse" default="false"/>
+      <xsd:attribute name="lazy-factory" type="trueOrFalse">
+        <xsd:annotation>
+          <xsd:documentation>
+            If true, @Factory produced test class instances are created lazily (just-in-time,
+            right before the first configuration/test method of each instance runs) instead of
+            eagerly up-front. Honored only for constructor based factories. When unset, the TestNG
+            configuration decides (default eager). A @Factory(lazy=...) annotation value overrides
+            this suite level attribute.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="preserve-order" type="trueOrFalse" default="true"/>
+      <xsd:attribute name="allow-return-values" type="trueOrFalse" default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            If true, tests that return a value will be run as well.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="suite-files">
+    <xsd:annotation>
+      <xsd:documentation>
+        A list of XML files that contain more suite descriptions.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="suite-file" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="suite-file">
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="path" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="parameter">
+    <xsd:annotation>
+      <xsd:documentation>
+        Parameters can be defined at the suite or at the test level. Parameters defined at the
+        test level override parameters of the same name in the suite. Parameters are used to link
+        Java method parameters to their actual value, defined here.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="value" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="method-selectors">
+    <xsd:annotation>
+      <xsd:documentation>
+        Method selectors define user classes used to select which methods to run. They need to
+        implement org.testng.IMethodSelector.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="method-selector" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="method-selector">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element ref="selector-class" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="script"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="selector-class">
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="priority" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="script">
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="language" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="test">
+    <xsd:annotation>
+      <xsd:documentation>
+        A test contains parameters and classes. Additionally, you can define additional groups
+        ("groups of groups").
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="method-selectors" minOccurs="0"/>
+        <xsd:element ref="parameter" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="groups" minOccurs="0"/>
+        <xsd:element ref="packages" minOccurs="0"/>
+        <xsd:element ref="classes" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            The name of this test (as it will appear in the reports).
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="verbose" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            How verbose the output on the console will be. This setting has no impact on the
+            HTML reports. Default value: suite level verbose.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="parallel" type="parallelMode">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether TestNG should use different threads to run your tests (might speed up the
+            process). Do not use "true" and "false" values, they are now deprecated.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="thread-count" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            An integer giving the size of the thread pool to be used if parallel mode is used.
+            Overrides the suite level value.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="annotations" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            If "javadoc", TestNG will look for JavaDoc annotations in your sources, otherwise it
+            will use JDK5 annotations.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="time-out" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The time to wait in milliseconds before aborting the method (if parallel="methods")
+            or the test (if parallel="tests").
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="enabled" type="trueOrFalse">
+        <xsd:annotation>
+          <xsd:documentation>
+            Flag to enable/disable the current test. Default value: true.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="skipfailedinvocationcounts" type="trueOrFalse" default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            Whether to skip failed invocations.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="preserve-order" type="trueOrFalse" default="true">
+        <xsd:annotation>
+          <xsd:documentation>
+            If true, the classes in this tag will be run in the same order as found in the XML
+            file.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="group-by-instances" type="trueOrFalse" default="false"/>
+      <xsd:attribute name="allow-return-values" type="trueOrFalse" default="false">
+        <xsd:annotation>
+          <xsd:documentation>
+            If true, tests that return a value will be run as well.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="groups">
+    <xsd:annotation>
+      <xsd:documentation>
+        Defines additional groups ("groups of groups") and also which groups to include in this
+        test run.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="define" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="run" minOccurs="0"/>
+        <xsd:element ref="dependencies" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="define">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="include" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="include">
+    <xsd:annotation>
+      <xsd:documentation>
+        Defines which groups to include in the current group of groups.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="description" type="xsd:string"/>
+      <xsd:attribute name="invocation-numbers" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="exclude">
+    <xsd:annotation>
+      <xsd:documentation>
+        Defines which groups to exclude from the current group of groups.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="run">
+    <xsd:annotation>
+      <xsd:documentation>
+        The subtag of groups used to define which groups should be run.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="include"/>
+        <xsd:element ref="exclude"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="dependencies">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="group" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="group">
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="depends-on" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="classes">
+    <xsd:annotation>
+      <xsd:documentation>
+        The list of classes to include in this test.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="class" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="parameter" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="class">
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="methods"/>
+        <xsd:element ref="parameter"/>
+      </xsd:choice>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="packages">
+    <xsd:annotation>
+      <xsd:documentation>
+        The list of packages to include in this test.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="package">
+    <xsd:annotation>
+      <xsd:documentation>
+        The package description. If the package name ends with .* then subpackages are included
+        too.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="include"/>
+        <xsd:element ref="exclude"/>
+      </xsd:choice>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="methods">
+    <xsd:annotation>
+      <xsd:documentation>
+        The list of methods to include in or exclude from this test.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="include"/>
+        <xsd:element ref="exclude"/>
+        <xsd:element ref="parameter"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="listeners">
+    <xsd:annotation>
+      <xsd:documentation>
+        The list of listeners that will be passed to TestNG.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="listener" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="listener">
+    <xsd:complexType mixed="true">
+      <xsd:group ref="anyDeclaredElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="class-name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    Shared definitions.
+
+    anyDeclaredElement is what the DTD writes as ANY: any declared element, in any order, mixed
+    with character data. Elements declared ANY in the DTD use it rather than a tighter model,
+    because suite files do rely on it: <parameter> appears inside <suite-file> and inside
+    <include>, neither of which the reader would reject.
+  -->
+  <xsd:group name="anyDeclaredElement">
+    <xsd:choice>
+      <xsd:element ref="suite"/>
+      <xsd:element ref="suite-files"/>
+      <xsd:element ref="suite-file"/>
+      <xsd:element ref="parameter"/>
+      <xsd:element ref="method-selectors"/>
+      <xsd:element ref="method-selector"/>
+      <xsd:element ref="selector-class"/>
+      <xsd:element ref="script"/>
+      <xsd:element ref="test"/>
+      <xsd:element ref="groups"/>
+      <xsd:element ref="define"/>
+      <xsd:element ref="include"/>
+      <xsd:element ref="exclude"/>
+      <xsd:element ref="run"/>
+      <xsd:element ref="dependencies"/>
+      <xsd:element ref="group"/>
+      <xsd:element ref="classes"/>
+      <xsd:element ref="class"/>
+      <xsd:element ref="packages"/>
+      <xsd:element ref="package"/>
+      <xsd:element ref="methods"/>
+      <xsd:element ref="listeners"/>
+      <xsd:element ref="listener"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:simpleType name="parallelMode">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="false">
+        <xsd:annotation>
+          <xsd:documentation>Deprecated.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="true">
+        <xsd:annotation>
+          <xsd:documentation>Deprecated.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="methods"/>
+      <xsd:enumeration value="tests"/>
+      <xsd:enumeration value="classes"/>
+      <xsd:enumeration value="instances"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="guiceStage">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="DEVELOPMENT"/>
+      <xsd:enumeration value="PRODUCTION"/>
+      <xsd:enumeration value="TOOL"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="configFailurePolicy">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="skip"/>
+      <xsd:enumeration value="continue"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!--
+    The DTD spells these attributes (true | false), not a boolean type. xsd:boolean would also
+    accept 0 and 1, which would make this schema quietly looser than the DTD it mirrors.
+  -->
+  <xsd:simpleType name="trueOrFalse">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="true"/>
+      <xsd:enumeration value="false"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
Publishes `testng-1.1.xsd`, and refreshes the DTD that sits next to it.

## Why now

testng-team/testng#3357 lets a suite file declare the schema instead of a doctype, and writes that
declaration into everything TestNG generates — `testng-failed.xml` is rewritten on every failing run:

```xml
<suite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="https://testng.org/testng-1.1.xsd" name="…">
```

TestNG does not need the address to resolve: it validates against the copy in its own jar and never
fetches. The declaration exists for everything else — IDE completion, standalone validators, CI schema
checks — and those get a 404 today.

## The drift found on the way

The served DTD had fallen behind the one TestNG ships, and nothing was watching:

| | served today | in the jar |
|---|---|---|
| `junit` on `<suite>` / `<test>` | declared | removed in 7.9.0 |
| `lazy-factory` on `<suite>` | absent | added since |

So a tool resolving `https://testng.org/testng-1.1.dtd` validates against a grammar no supported
release agrees with — it accepts `junit="true"`, which TestNG now rejects outright, and reports
`lazy-factory` as undeclared. It went unnoticed because TestNG never reads it: the entity resolver
serves the DTD from the classpath for any `testng.org` or `beust.com` system id. The same class of
drift inside the repository was fixed by testng-team/testng#3315, where the writer advertised
`testng-1.0.dtd` while the reader resolved 1.1.

Both files are copied verbatim from `testng-core/src/main/resources/`, so a stray edit cannot make
them differ.

## One thing to decide

Both copies are taken from `master`, not from the 7.12.0 tag, so they include `lazy-factory`, which is
unreleased. That is safe in the permissive direction — an optional attribute a 7.12 user cannot use
anyway — and it is what testng-team/testng#3357 will reference once released. Say the word if you would
rather track the released tag instead; the DTD commit is separate so it can be dropped on its own.

Note the XSD itself is unreleased too: it only exists on `master`, added by testng-team/testng#3319.

## How it is wired

`src/main/resources/schema/**/*.xsd` gets its own `<resource>` block rather than widening the `dtd`
one — a file called `*.xsd` does not belong in a directory called `dtd`. Both land flat at the site
root, as the DTDs already do.

Verified with `./mvnw -B process-resources`:

```
target/html/testng-1.0.dtd
target/html/testng-1.1.dtd
target/html/testng-1.1.xsd
```

and both published files compare byte-identical to the ones in the TestNG jar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an XML Schema definition for TestNG 1.1 suite configuration files, including validation for suites, tests, groups, classes, packages, methods, listeners, and related settings.
  * Added validation for supported parallel modes, Guice stages, configuration failure policies, and boolean values.
  * Added support for the optional suite-level `lazy-factory` setting.

* **Changes**
  * Removed the obsolete `junit` attribute from suite and test configuration definitions.
  * Schema resources are now included during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->